### PR TITLE
binary: forward LittleEndian and BigEndian vars from encoding/binary

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -11,7 +11,9 @@ import (
 )
 
 var (
-	DefaultEndian = binary.LittleEndian
+	LittleEndian  = binary.LittleEndian
+	BigEndian     = binary.BigEndian
+	DefaultEndian = LittleEndian
 )
 
 func Marshal(v interface{}) ([]byte, error) {


### PR DESCRIPTION
forwards `binary.LittleEndian` and `binary.BigEndian` vars from `encoding/binary`

this is mostly for convenience so users don't have to:

``` go
 import  (
  encbin "encoding/binary"
  "github.com/alecthomas/binary"
)
```

just for these 2 vars.
