### PR TITLE
benchmark struct of struct of int64

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -260,9 +260,12 @@ func TestSliceOfStructWithStruct(t *testing.T) {
 
 func BenchmarkEncodeStructI1(b *testing.B) {
 	type Struct struct {
-		I int64
+		S struct {
+			I int64
+		}
 	}
-	s := Struct{I: 1024}
+	var s Struct
+	s.S.I = 1024
 	buf := new(bytes.Buffer)
 
 	b.ResetTimer()
@@ -275,9 +278,12 @@ func BenchmarkEncodeStructI1(b *testing.B) {
 
 func BenchmarkEncodeStructI2(b *testing.B) {
 	type Struct struct {
-		I int64
+		S struct {
+			I int64
+		}
 	}
-	s := Struct{I: 1024}
+	var s Struct
+	s.S.I = 1024
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf)
 
@@ -290,9 +296,12 @@ func BenchmarkEncodeStructI2(b *testing.B) {
 
 func BenchmarkEncodeStructI3(b *testing.B) {
 	type Struct struct {
-		I int64
+		S struct {
+			I int64
+		}
 	}
-	s := Struct{I: 1024}
+	var s Struct
+	s.S.I = 1024
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf)
 
@@ -344,9 +353,10 @@ func BenchmarkDecodeStructI1(b *testing.B) {
 func BenchmarkDecodeStructI2(b *testing.B) {
 
 	type Struct struct {
-		I int64
+		S struct {
+			I int64
+		}
 	}
-
 	var s Struct
 
 	buf := getTestBuffer(b)
@@ -362,9 +372,10 @@ func BenchmarkDecodeStructI2(b *testing.B) {
 func BenchmarkDecodeStructI3(b *testing.B) {
 
 	type Struct struct {
-		I int64
+		S struct {
+			I int64
+		}
 	}
-
 	var s Struct
 
 	buf := getTestBuffer(b)


### PR DESCRIPTION
benchmark encoding and decoding a struct of struct of int64.

perfs before c8dd3d1 (ie: b46c98d)

```
BenchmarkEncodeStructI1  5000000           689 ns/op
BenchmarkEncodeStructI2  5000000           372 ns/op
BenchmarkEncodeStructI3  5000000           365 ns/op
BenchmarkDecodeStructI1  2000000           807 ns/op
BenchmarkDecodeStructI2  2000000           805 ns/op
BenchmarkDecodeStructI3  2000000           811 ns/op
```

perfs after c8dd3d1 (ie: ad72c3c)

```
BenchmarkEncodeStructI1  1000000          1107 ns/op
BenchmarkEncodeStructI2  2000000           782 ns/op
BenchmarkEncodeStructI3  2000000           786 ns/op
BenchmarkDecodeStructI1  2000000           803 ns/op
BenchmarkDecodeStructI2  2000000           849 ns/op
BenchmarkDecodeStructI3  2000000           801 ns/op
```

encoding of course takes way more time (as before c8dd3d1 the embedded struct was dropped on the floor)

for comparison, here is the before/after for a simple struct holding one int64:

before

```
BenchmarkEncodeStructI1  2000000           808 ns/op
BenchmarkEncodeStructI2  5000000           516 ns/op
BenchmarkEncodeStructI3  5000000           514 ns/op
BenchmarkDecodeStructI1  2000000           862 ns/op
BenchmarkDecodeStructI2  5000000           531 ns/op
BenchmarkDecodeStructI3  5000000           510 ns/op
```

after

```
BenchmarkEncodeStructI1  2000000           789 ns/op
BenchmarkEncodeStructI2  5000000           493 ns/op
BenchmarkEncodeStructI3  5000000           496 ns/op
BenchmarkDecodeStructI1  2000000           834 ns/op
BenchmarkDecodeStructI2  5000000           512 ns/op
BenchmarkDecodeStructI3  5000000           487 ns/op
```

everything is in the noise.
