### PR TITLE
Adding NewStrictEncoder

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -29,9 +29,10 @@ func Unmarshal(b []byte, v interface{}) error {
 }
 
 type Encoder struct {
-	Order binary.ByteOrder
-	w     io.Writer
-	buf   []byte
+	Order  binary.ByteOrder
+	w      io.Writer
+	buf    []byte
+	strict bool
 }
 
 func NewEncoder(w io.Writer) *Encoder {
@@ -40,6 +41,16 @@ func NewEncoder(w io.Writer) *Encoder {
 		w:     w,
 		buf:   make([]byte, 8),
 	}
+}
+
+// NewStrictEncoder creates an encoder similar to NewEncoder, however
+// if this encoder attempts to encode a struct and the struct has no encodable
+// fields an error is returned whereas the encoder returned from NewEncoder
+// will simply not write anything to `w`.
+func NewStrictEncoder(w io.Writer) *Encoder {
+	e := NewEncoder(w)
+	e.strict = true
+	return e
 }
 
 func (e *Encoder) writeVarint(v int) error {
@@ -91,6 +102,7 @@ func (b *Encoder) Encode(v interface{}) (err error) {
 
 		case reflect.Struct:
 			l := rv.NumField()
+			n := 0
 			for i := 0; i < l; i++ {
 				if v := rv.Field(i); v.CanSet() && t.Field(i).Name != "_" {
 					// take the address of the field, so structs containing structs
@@ -98,7 +110,11 @@ func (b *Encoder) Encode(v interface{}) (err error) {
 					if err = b.Encode(v.Addr().Interface()); err != nil {
 						return
 					}
+					n++
 				}
+			}
+			if b.strict && n == 0 {
+				return fmt.Errorf("binary: struct had no encodable fields")
 			}
 
 		case reflect.Map:


### PR DESCRIPTION
Hi!

I ran into an unexpected behaviour when using the binary Encoder which was different from what I expected from other packages that have a method `Encode(interface{}) error` (such as gob or JSON); namely that the parameter passed to Encode() must be addressable. When I changed from using the gob and json encoders to this one my protocol hung unexpectedly because I was passing structs instead of pointers to structs so no bytes were encoded and no error was returned, and so the remote protocol peer ended up waiting for something that never arrived. I had to change all places where I passed a struct to pass a pointer to the struct instead.

This is fine, but I can imagine in the future making the same mistake in some place in the code (say after using a different encoder) and having to troubleshoot it again to figure out what went wrong. To make it easier to figure out these kind of mistakes I'm proposing adding a second constructor that creates an encoder that checks for this sort of error and returns an error instead of silently "failing" (it's not necessarily a failure for all use cases, but it is in my case). 

If you don't like this solution please feel free to modify it or let me know of other fixes.