### PR TITLE
support marshaling non-pointer struct

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -104,10 +104,8 @@ func (b *Encoder) Encode(v interface{}) (err error) {
 			l := rv.NumField()
 			n := 0
 			for i := 0; i < l; i++ {
-				if v := rv.Field(i); v.CanSet() && t.Field(i).Name != "_" {
-					// take the address of the field, so structs containing structs
-					// are correctly encoded.
-					if err = b.Encode(v.Addr().Interface()); err != nil {
+				if v := rv.Field(i); t.Field(i).Name != "_" {
+					if err = b.Encode(v.Interface()); err != nil {
 						return
 					}
 					n++

--- a/binary_test.go
+++ b/binary_test.go
@@ -258,6 +258,24 @@ func TestSliceOfStructWithStruct(t *testing.T) {
 
 }
 
+func TestMarshalNonPointer(t *testing.T) {
+	type S struct {
+		A int
+	}
+	s := S{A: 1}
+	data, err := Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res S
+	if err := Unmarshal(data, &res); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res, s) {
+		t.Fatalf("expect %v got %v", s, res)
+	}
+}
+
 func BenchmarkEncodeStructI1(b *testing.B) {
 	type Struct struct {
 		S struct {


### PR DESCRIPTION
After removing the restriction, all tests can still pass.

A test case for marshaling non-pointer struct is also added.