### PR TITLE
Prevent panic on `struct` types containing unexported fields

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -104,7 +104,7 @@ func (b *Encoder) Encode(v interface{}) (err error) {
 			l := rv.NumField()
 			n := 0
 			for i := 0; i < l; i++ {
-				if v := rv.Field(i); t.Field(i).Name != "_" {
+				if v := rv.Field(i); t.Field(i).Name != "_" && t.Field(i).IsExported() {
 					if err = b.Encode(v.Interface()); err != nil {
 						return
 					}

--- a/binary_test.go
+++ b/binary_test.go
@@ -276,6 +276,36 @@ func TestMarshalNonPointer(t *testing.T) {
 	}
 }
 
+func TestStructWithPrivateFields(t *testing.T) {
+
+	type S struct {
+		Public        int
+		AnotherPublic int
+		private       int
+	}
+
+	s := S{
+		Public:        123,
+		AnotherPublic: 456,
+		private:       -555,
+	}
+
+	assert.NotPanics(t, func() {
+
+		data, err := Marshal(s)
+		assert.NoError(t, err)
+
+		var res S
+		if err := Unmarshal(data, &res); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, s.Public, res.Public)
+		assert.Equal(t, s.AnotherPublic, res.AnotherPublic)
+
+	})
+
+}
+
 func BenchmarkEncodeStructI1(b *testing.B) {
 	type Struct struct {
 		S struct {


### PR DESCRIPTION
Encoder panics when it encounters a private/unexported field within a struct.

This PR proposes skipping those unexported fields.